### PR TITLE
Update ZebraRfid.java

### DIFF
--- a/zebraRfid/android/src/main/java/support/lib/rfid/ZebraRfid.java
+++ b/zebraRfid/android/src/main/java/support/lib/rfid/ZebraRfid.java
@@ -269,7 +269,7 @@ public class ZebraRfid extends BroadcastReceiver implements ZebraDevice, RfidEve
     @Override
     public void setMode(Modes mode) {
         try {
-        this.mode = mode;
+         this.mode = Modes.rfid;
         Log.d("RFIDPlugin", "Set mode method evoked and the mode is "+mode.toString());
         switch (mode) {
             case barcode:


### PR DESCRIPTION
fix: set rfid as default mode for fixing camera open issue